### PR TITLE
create interface for getImage(), add this interface as an input to signupcubit & profilecubit, add avator upload test

### DIFF
--- a/lib/auth/sign_up/cubit/sign_up_cubit.dart
+++ b/lib/auth/sign_up/cubit/sign_up_cubit.dart
@@ -14,12 +14,15 @@ class SignUpCubit extends Cubit<SignUpState> {
   SignUpCubit({
     required IAuthenticationRepository authenticationRepository,
     required IStorageRepository storageRepository,
+    required IImagePicker imagePicker,
   })  : _authenticationRepository = authenticationRepository,
         _storageRepository = storageRepository,
+        _imagePicker = imagePicker,
         super(const SignUpState());
 
   final IAuthenticationRepository _authenticationRepository;
   final IStorageRepository _storageRepository;
+  final IImagePicker _imagePicker;
 
   void nameChanged(String value) {
     final name = value;
@@ -70,7 +73,7 @@ class SignUpCubit extends Cubit<SignUpState> {
   Future<void> uploadAvatar(bool gallery) async {
     try {
       // emit(state.copyWith(status: FormzStatus.submissionInProgress));
-      final _image = await getImage(gallery);
+      final _image = await _imagePicker.getImage(gallery);
       final _url = await _storageRepository.uploadImage(image: _image);
       emit(state.copyWith(
         photo: _url,

--- a/lib/auth/sign_up/view/sign_up_page.dart
+++ b/lib/auth/sign_up/view/sign_up_page.dart
@@ -27,6 +27,7 @@ class SignUpPage extends StatelessWidget {
           create: (_) => SignUpCubit(
             authenticationRepository: context.read<IAuthenticationRepository>(),
             storageRepository: context.read<IStorageRepository>(),
+            imagePicker: ImagePicker(),  // image picker need not be from context
           ),
           child: const SignUpForm(),
         ),

--- a/lib/profile/cubit/profile_cubit.dart
+++ b/lib/profile/cubit/profile_cubit.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:authentication_repository/authentication_repository.dart';
 import 'package:bloc/bloc.dart';
+// import 'package:custom_utils/custom_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:form_inputs/form_inputs.dart';
 import 'package:formz/formz.dart';
@@ -19,9 +20,11 @@ class ProfileCubit extends Cubit<ProfileState> {
     required AppBloc bloc,
     required IAuthenticationRepository authenticationRepository,
     required IStorageRepository storageRepository,
+    required IImagePicker imagePicker,
   })  : _bloc = bloc,
         _authenticationRepository = authenticationRepository,
         _storageRepository = storageRepository,
+        _imagePicker = imagePicker,
         super(const ProfileState()) {
     emit(ProfileState(
       isEditing: false,
@@ -44,6 +47,7 @@ class ProfileCubit extends Cubit<ProfileState> {
   final IAuthenticationRepository _authenticationRepository;
   final IStorageRepository _storageRepository;
   late final StreamSubscription<AppState> _appBlocSubscription;
+  final IImagePicker _imagePicker;
 
   /// Handles switching between Static profile view and Editing profile view
   void editing(bool isEditing) {
@@ -107,7 +111,7 @@ class ProfileCubit extends Cubit<ProfileState> {
   Future<void> uploadAvatar(bool gallery) async {
     try {
       // emit(state.copyWith(status: FormzStatus.submissionInProgress));
-      final _image = await getImage(gallery);
+      final _image = await _imagePicker.getImage(gallery);
       final _url = await _storageRepository.uploadImage(image: _image);
       emit(state.copyWith(
         photo: _url,

--- a/lib/profile/view/profile_page.dart
+++ b/lib/profile/view/profile_page.dart
@@ -19,6 +19,7 @@ class ProfilePage extends StatelessWidget {
         authenticationRepository: context.read<IAuthenticationRepository>(),
         storageRepository: context.read<IStorageRepository>(),
         bloc: context.read<AppBloc>(),
+        imagePicker: ImagePicker(),  // image picker need not be from context
       ),
       child: const ProfileView(),
     );

--- a/packages/file_storage/lib/src/services/i_image_picker.dart
+++ b/packages/file_storage/lib/src/services/i_image_picker.dart
@@ -1,0 +1,15 @@
+import 'dart:io'; 
+import 'package:storage_repository/storage_repository.dart';
+
+// Interface to interact with gallary; also provide convenience for testing purposes.
+abstract class IImagePicker {
+  Future<File> getImage(bool fromGallary);
+}
+
+// A concrete class for the IImagePicker interface.
+// Extract out the getImage() utility function into an image picker interface. 
+class ImagePicker implements IImagePicker {
+  Future<File> getImage(bool fromGallary) {
+    return pickImage(fromGallary);
+  }
+}

--- a/packages/file_storage/lib/src/services/mock/mock_image_picker.dart
+++ b/packages/file_storage/lib/src/services/mock/mock_image_picker.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'package:storage_repository/storage_repository.dart';
+
+// This is a mock that implements the dummy getImage() call. 
+class MockImagePicker implements IImagePicker {
+  MockImagePicker(File mockFile)  : _mockFile = mockFile;
+
+  File _mockFile;
+
+  @override
+  Future<File> getImage(bool fromGallary) {
+    return Future.delayed(
+        Duration(milliseconds: 100), () => _mockFile);
+  }
+
+  void setMockFile(File newFile) {
+    _mockFile = newFile;
+  }
+}

--- a/packages/file_storage/lib/src/services/mock/mock_service.dart
+++ b/packages/file_storage/lib/src/services/mock/mock_service.dart
@@ -1,1 +1,2 @@
+export 'mock_image_picker.dart';
 export 'mock_storage_repository.dart';

--- a/packages/file_storage/lib/src/services/services.dart
+++ b/packages/file_storage/lib/src/services/services.dart
@@ -1,3 +1,4 @@
 export 'firebase/firebase_service.dart';
+export 'i_image_picker.dart';
 export 'i_storage_repository.dart';
 export 'mock/mock_service.dart';

--- a/packages/file_storage/lib/src/utils/pick_image.dart
+++ b/packages/file_storage/lib/src/utils/pick_image.dart
@@ -6,7 +6,7 @@ import 'package:image_picker/image_picker.dart';
 /// or prompts the user to use the camera if [gallery] is false
 ///
 /// Returns a [File] with the selected image's path
-Future<File> getImage(bool gallery) async {
+Future<File> pickImage(bool gallery) async {
   ImagePicker picker = ImagePicker();
   XFile? pickedFile;
 


### PR DESCRIPTION
This PR might take some time to review/reject.

Motivation:
In unit tests, however we stub/mock the getImage() function in the test suite, the signupcubit's uploadAvator() method will always call the actual implementation of getImage(), thus always throwing FileSystemException. (I suspect this has to do with how dart/flutter load imported libraries, such that the tested uploadAvator() will always load the actually implementation imported)

Few changes:
1) extract utility function getImage() out as a method of interface **IImagePicker**
  - see no harm in doing so.
  - convenience for testing. 
  - changed files: 
    - packages/file_storage/lib/src/services/i_image_picker.dart
    - packages/file_storage/lib/src/services/services.dart
    - packages/file_storage/lib/src/utils/pick_image.dart
    - packages/file_storage/lib/src/services/mock/mock_image_picker.dart (mock)
    - packages/file_storage/lib/src/services/mock/mock_service.dart (mock)
2) add an input of type **IImagePicker** to signupcubit & profilecubit, such that their image/avator methods call this **IImagePicker** object's method
  - changed files:
    - lib/auth/sign_up/cubit/sign_up_cubit.dart
    - lib/auth/sign_up/view/sign_up_page.dart
    - lib/profile/cubit/profile_cubit.dart
    - lib/profile/view/profile_page.dart
3) add tests for uploadAvator() after this change in sign_up_cubit_test.dart.
  - changed files:
    - test/sign_up/cubit/sign_up_cubit_test.dart

Tests:
unit tests passed
